### PR TITLE
AMAAS-832 Added rate child to transactions. Removed obsolete active f…

### DIFF
--- a/amaascore/assets/enums.py
+++ b/amaascore/assets/enums.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 WINE_CLASSIFICATIONS = {'1er Cru', '1er Cru Classé', '1er Grand Cru', '2ème Cru Classé', '2ème Vin',

--- a/amaascore/csv_upload/utils.py
+++ b/amaascore/csv_upload/utils.py
@@ -21,7 +21,7 @@ from amaascore import transactions
 
 from amaascore.assets.children import Link, Reference
 from amaascore.parties.children import Address, Email, Link, Reference, Comment
-from amaascore.transactions.children import Charge, Code, Comment, Link, Party, Reference
+from amaascore.transactions.children import Charge, Code, Comment, Link, Party, Rate, Reference
 
 CHILDREN_CLASS = {'asset': {'links': assets.children.Link, 'references': assets.children.Reference},
                   'party': {'addresses': parties.children.Address, 'emails': parties.children.Email,
@@ -29,7 +29,8 @@ CHILDREN_CLASS = {'asset': {'links': assets.children.Link, 'references': assets.
                             'comments': parties.children.Comment},
                   'transaction': {'charges': transactions.children.Charge, 'codes': transactions.children.Code,
                                   'comments': transactions.children.Comment, 'links': transactions.children.Link,
-                                  'references': transactions.children.Reference, 'parties': transactions.children.Party},
+                                  'rates': transactions.children.Rate, 'parties': transactions.children.Party,
+                                  'references': transactions.children.Reference},
                   'asset_manager': {},
                   'book': {},
                   'corporate_action': {'references': assets.children.Reference}} #no Reference class found in corporate_actions

--- a/amaascore/tools/generate_transaction.py
+++ b/amaascore/tools/generate_transaction.py
@@ -5,9 +5,8 @@ import datetime
 from decimal import Decimal
 import random
 
-from amaascore.core.reference import Reference
 from amaascore.transactions.cash_transaction import CashTransaction
-from amaascore.transactions.children import Charge, Code, Comment, Link, Party
+from amaascore.transactions.children import Charge, Code, Comment, Link, Party, Rate, Reference
 from amaascore.transactions.enums import TRANSACTION_ACTIONS, CASH_TRANSACTION_TYPES
 from amaascore.transactions.position import Position
 from amaascore.transactions.transaction import Transaction
@@ -16,6 +15,7 @@ CHARGE_TYPES = ['Tax', 'Commission']
 CODE_TYPES = ['Settle Code', 'Client Classifier']
 COMMENT_TYPES = ['Trader']
 PARTY_TYPES = ['Prime Broker']
+RATE_TYPES = ['Tax', 'Commission']
 REFERENCE_TYPES = ['External']
 
 
@@ -66,6 +66,9 @@ def generate_transaction(asset_manager_id=None, asset_book_id=None, counterparty
     codes = {code_type: Code(code_value=random_string(8)) for code_type in CODE_TYPES}
     comments = {comment_type: Comment(comment_value=random_string(8)) for comment_type in COMMENT_TYPES}
     parties = {party_type: Party(party_id=random_string(8)) for party_type in PARTY_TYPES}
+    rates = {rate_type:
+             Rate(rate_value=Decimal(random.uniform(1.0, 100.0)).quantize(Decimal('0.01')))
+             for rate_type in RATE_TYPES}
     references = {ref_type: Reference(reference_value=random_string(10)) for ref_type in REFERENCE_TYPES}
 
     transaction.charges.update(charges)
@@ -73,6 +76,7 @@ def generate_transaction(asset_manager_id=None, asset_book_id=None, counterparty
     transaction.comments.update(comments)
     transaction.links.update(links)
     transaction.parties.update(parties)
+    transaction.rates.update(rates)
     transaction.references.update(references)
     return transaction
 

--- a/amaascore/transactions/cash_transaction.py
+++ b/amaascore/transactions/cash_transaction.py
@@ -8,8 +8,8 @@ class CashTransaction(Transaction):
     def __init__(self, asset_manager_id, asset_book_id, counterparty_book_id, transaction_action,
                  asset_id, quantity, transaction_date, settlement_date, asset=None, execution_time=None,
                  transaction_type='Trade', transaction_id=None, transaction_status='New',
-                 charges=None, codes=None, comments=None, links=None, parties=None, references=None,
-                 *args, **kwargs):
+                 charges=None, codes=None, comments=None, links=None, parties=None,
+                 rates=None, references=None, *args, **kwargs):
         """
 
         :param asset_manager_id:
@@ -34,6 +34,7 @@ class CashTransaction(Transaction):
         :param comments:
         :param links:
         :param parties:
+        :param rates:
         :param references:
         :param args:
         :param kwargs:
@@ -60,5 +61,6 @@ class CashTransaction(Transaction):
                                               comments=comments,
                                               links=links,
                                               parties=parties,
+                                              rates=rates,
                                               references=references,
                                               *args, **kwargs)

--- a/amaascore/transactions/children.py
+++ b/amaascore/transactions/children.py
@@ -7,10 +7,9 @@ from amaascore.core.amaas_model import AMaaSModel
 
 class Charge(AMaaSModel):
 
-    def __init__(self, charge_value, currency, active=True, net_affecting=True, version=1, *args, **kwargs):
+    def __init__(self, charge_value, currency, net_affecting=True, version=1, *args, **kwargs):
         self.charge_value = charge_value
         self.currency = currency
-        self.active = active
         self.net_affecting = net_affecting
         self.version = version
         super(Charge, self).__init__(*args, **kwargs)
@@ -31,43 +30,60 @@ class Charge(AMaaSModel):
 
 class Code(AMaaSModel):
 
-    def __init__(self, code_value, active=True, version=1, *args, **kwargs):
+    def __init__(self, code_value, version=1, *args, **kwargs):
         self.code_value = code_value
-        self.active = active
         self.version = version
         super(Code, self).__init__(*args, **kwargs)
 
 
 class Comment(AMaaSModel):
 
-    def __init__(self, comment_value, active=True, version=1, *args, **kwargs):
+    def __init__(self, comment_value, version=1, *args, **kwargs):
         self.comment_value = comment_value
-        self.active = active
         self.version = version
         super(Comment, self).__init__(*args, **kwargs)
 
 
 class Link(AMaaSModel):
 
-    def __init__(self, linked_transaction_id, active=True, version=1, *args, **kwargs):
+    def __init__(self, linked_transaction_id, version=1, *args, **kwargs):
         self.linked_transaction_id = linked_transaction_id
-        self.active = active
         self.version = version
         super(Link, self).__init__(*args, **kwargs)
 
 
 class Party(AMaaSModel):
 
-    def __init__(self, party_id, active=True, version=1, *args, **kwargs):
+    def __init__(self, party_id, version=1, *args, **kwargs):
         self.party_id = party_id
-        self.active = active
         self.version = version
         super(Party, self).__init__(*args, **kwargs)
 
+
+class Rate(AMaaSModel):
+    
+    def __init__(self, rate_value, version=1, *args, **kwargs):
+        self.rate_value = rate_value
+        self.version = version
+        super(Rate, self).__init__(*args, **kwargs)
+
+    @property
+    def rate_value(self):
+        return self._rate_value
+
+    @rate_value.setter
+    def rate_value(self, value):
+        """
+        Force the charge_value to always be a decimal
+        :param value:
+        :return:
+        """
+        self._rate_value = Decimal(value)
+
+
 class Reference(AMaaSModel):
     
-    def __init__(self, reference_value, active=True, *args, **kwargs):
+    def __init__(self, reference_value, *args, **kwargs):
         self.reference_value = reference_value
-        self.active = active
         super(Reference, self).__init__(*args, **kwargs)
 

--- a/tests/unit/transactions/transaction.py
+++ b/tests/unit/transactions/transaction.py
@@ -31,19 +31,9 @@ class TransactionTest(unittest.TestCase):
         """
         total = 0
         for charge in self.transaction.charges.values():
-            if charge.net_affecting and charge.active:
+            if charge.net_affecting:
                 total += charge.charge_value
         self.assertEqual(self.transaction.charges_net_effect(), total)
-
-    def test_ChargesNetEffectWithInactiveCharge(self):
-        # Set one of the charges to Inactive
-        original_total = self.transaction.charges_net_effect()
-        tax = self.transaction.charges.get('Tax')
-        tax_value = tax.charge_value
-        tax.active = False
-        new_total = self.transaction.charges_net_effect()
-        self.assertNotEqual(original_total, new_total)
-        self.assertEqual(original_total-tax_value, new_total)
 
     def test_TransactionNetSettlement(self):
         """
@@ -52,7 +42,7 @@ class TransactionTest(unittest.TestCase):
         """
         total = 0
         for charge in self.transaction.charges.values():
-            if charge.net_affecting and charge.active:
+            if charge.net_affecting:
                 total += charge.charge_value
         self.assertEqual(self.transaction.net_settlement, self.transaction.gross_settlement - total)
 


### PR DESCRIPTION
@nedlowe please review the changes

- Added rate child to transaction
- Removed obsolete flag 'active' from transaction children
- Removed obsolete test test_ChargesNetEffectWithInactiveCharge (do we still need an equivalent since removed charges will not be part of the transaction children?)
- Added unicode encoding on enums.py (noticed that this is also giving an error in our CI build)