### PR TITLE
AMAAS-977 Allow sdk clients to specify credentials. 

### DIFF
--- a/amaascore/asset_managers/interface.py
+++ b/amaascore/asset_managers/interface.py
@@ -12,10 +12,10 @@ class AssetManagersInterface(Interface):
     The interface to the Asset Managers service for reading Asset Manager information.
     """
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
         super(AssetManagersInterface, self).__init__(endpoint=endpoint, endpoint_type='asset_managers',
-                                                     environment=environment)
+                                                     environment=environment, username=username, password=password)
 
     def new(self, asset_manager):
         self.logger.info('New Asset Manager: %s', asset_manager.asset_manager_id)

--- a/amaascore/assets/interface.py
+++ b/amaascore/assets/interface.py
@@ -11,9 +11,10 @@ from amaascore.core.amaas_model import json_handler
 
 class AssetsInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, endpoint=None, logger=None):
+    def __init__(self, environment=ENVIRONMENT, endpoint=None, logger=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
-        super(AssetsInterface, self).__init__(endpoint=endpoint, endpoint_type='assets', environment=environment)
+        super(AssetsInterface, self).__init__(endpoint=endpoint, endpoint_type='assets',
+                                              environment=environment, username=username, password=password)
 
     def new(self, asset):
         self.logger.info('New Asset - Asset Manager: %s - Asset ID: %s', asset.asset_manager_id, asset.asset_id)

--- a/amaascore/books/interface.py
+++ b/amaascore/books/interface.py
@@ -9,10 +9,10 @@ from amaascore.core.interface import Interface
 
 class BooksInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         logger = logger or logging.getLogger(__name__)
         super(BooksInterface, self).__init__(endpoint=endpoint, endpoint_type='books', environment=environment,
-                                             logger=logger)
+                                             username=username, password=password, logger=logger)
 
     def new(self, book):
         self.logger.info('New Book - Asset Manager: %s - Book ID: %s', book.asset_manager_id, book.book_id)

--- a/amaascore/core/interface.py
+++ b/amaascore/core/interface.py
@@ -5,6 +5,7 @@ from configparser import ConfigParser, NoSectionError
 from datetime import datetime
 import logging
 from os.path import expanduser, join
+from os import environ
 import requests
 from warrant.aws_srp import AWSSRP
 
@@ -103,8 +104,8 @@ class Interface(object):
         self.environment = environment
         self.endpoint = endpoint or self.get_endpoint()
         self.json_header = {'Content-Type': 'application/json'}
-        username = username or self.read_config('username')
-        password = password or self.read_config('password')
+        username = username or environ.get('AMAAS_USERNAME') or self.read_config('username')
+        password = password or environ.get('AMAAS_PASSWORD') or self.read_config('password')
         self.session = AMaaSSession(username, password, self.logger)
         self.logger.info('Interface Created')
 

--- a/amaascore/corporate_actions/interface.py
+++ b/amaascore/corporate_actions/interface.py
@@ -9,10 +9,10 @@ from amaascore.corporate_actions.utils import json_to_corporate_action
 
 class CorporateActionsInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
         super(CorporateActionsInterface, self).__init__(endpoint=endpoint, endpoint_type='corporate_actions',
-                                                        environment=environment)
+                                                        environment=environment, username=username, password=password)
 
     def new(self, corporate_action):
         self.logger.info('New Corporate Action - Asset Manager: %s - Corporate Action ID: %s',

--- a/amaascore/fundamentals/interface.py
+++ b/amaascore/fundamentals/interface.py
@@ -9,10 +9,13 @@ from amaascore.core.interface import Interface
 
 class FundamentalsInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         logger = logger or logging.getLogger(__name__)
-        super(FundamentalsInterface, self).__init__(endpoint=endpoint, endpoint_type='fundamentals',
+        super(FundamentalsInterface, self).__init__(endpoint=endpoint,
+                                                    endpoint_type='fundamentals',
                                                     environment=environment,
+                                                    username=None, 
+                                                    password=None,
                                                     logger=logger)
 
     def countries(self, country_code=None):

--- a/amaascore/market_data/interface.py
+++ b/amaascore/market_data/interface.py
@@ -11,10 +11,10 @@ from amaascore.market_data.utils import json_to_eod_price, json_to_fx_rate
 
 class MarketDataInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
         super(MarketDataInterface, self).__init__(endpoint=endpoint, endpoint_type='market_data',
-                                                  environment=environment)
+                                                  environment=environment, username=username, password=password)
 
     def persist_eod_prices(self, asset_manager_id, business_date, eod_prices, update_existing_prices=True):
         """

--- a/amaascore/monitor/interface.py
+++ b/amaascore/monitor/interface.py
@@ -9,9 +9,10 @@ from amaascore.monitor.utils import json_to_item
 
 class MonitorInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
-        super(MonitorInterface, self).__init__(endpoint=endpoint, endpoint_type='monitor', environment=environment)
+        super(MonitorInterface, self).__init__(endpoint=endpoint, endpoint_type='monitor', 
+                                               environment=environment, username=None, password=None)
 
     def new_item(self, item):
         url = '%s/items/%s' % (self.endpoint, item.asset_manager_id)

--- a/amaascore/parties/interface.py
+++ b/amaascore/parties/interface.py
@@ -11,9 +11,13 @@ from amaascore.parties.utils import json_to_party
 
 class PartiesInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
-        super(PartiesInterface, self).__init__(endpoint=endpoint, endpoint_type='parties', environment=environment)
+        super(PartiesInterface, self).__init__(endpoint=endpoint, 
+                                               endpoint_type='parties', 
+                                               environment=environment, 
+                                               username=None, 
+                                               password=None)
 
     def new(self, party):
         self.logger.info('New Party - Asset Manager: %s - Party ID: %s', party.asset_manager_id, party.party_id)

--- a/amaascore/transactions/interface.py
+++ b/amaascore/transactions/interface.py
@@ -11,10 +11,10 @@ from amaascore.transactions.utils import json_to_transaction, json_to_position
 
 class TransactionsInterface(Interface):
 
-    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None):
+    def __init__(self, environment=ENVIRONMENT, logger=None, endpoint=None, username=None, password=None):
         self.logger = logger or logging.getLogger(__name__)
         super(TransactionsInterface, self).__init__(endpoint=endpoint, endpoint_type='transactions',
-                                                    environment=environment)
+                                                    environment=environment, username=None, password=None)
 
     def new(self, transaction):
         self.logger.info('New Transaction - Asset Manager: %s - Transaction ID: %s', transaction.asset_manager_id,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = [
 
 setup(
     name='amaascore',
-    version='0.4.4',
+    version='0.4.5',
     description='Asset Management as a Service - Core SDK',
     license='Apache License 2.0',
     url='https://github.com/amaas-fintech/amaas-core-sdk-python',


### PR DESCRIPTION
The interface constructor already has username and password parameters.  I just exposed these in the inheriting XXXInterface classes' constructors.

Also added lookup to the following environment variables:
AMAAS_USERNAME
AMAAS_PASSWORD

The lookup chain is as follows:
1. The specified username and password in the XXXInterface constructor
2. The environment variables AMAAS_USERNAME and AMAAS_PASSWORD
3. The username and password specified in the ~/.amaas.cfg file

Note that there's nothing stopping an sdk client from specifying username in the constructor or environment variable but not the password; in which case the password lookup goes through the chain.