### PR TITLE
AMAAS-967 Added new api call to search assets and return only the spe…

### DIFF
--- a/amaascore/assets/interface.py
+++ b/amaascore/assets/interface.py
@@ -117,6 +117,27 @@ class AssetsInterface(Interface):
         else:
             self.logger.error(response.text)
             response.raise_for_status()
+    
+    def fields_search(self, asset_manager_ids=None, asset_ids=None, fields=None):
+        self.logger.info('Search for Assets - Asset Manager(s): %s', asset_manager_ids)
+        search_params = {}
+
+        if asset_manager_ids:
+            search_params['asset_manager_ids'] = ','.join([str(amid) for amid in asset_manager_ids])
+        if asset_ids:
+            search_params['asset_ids'] = ','.join(asset_ids)
+        if fields:
+            search_params['fields'] = ','.join(fields)
+
+        url = self.endpoint + '/assets'
+        response = self.session.get(url, params=search_params)
+        if response.ok:
+            asset_dicts = response.json()
+            self.logger.info('Returned %s Assets.', len(asset_dicts))
+            return asset_dicts
+        else:
+            self.logger.error(response.text)
+            response.raise_for_status()
 
     def assets_by_asset_manager(self, asset_manager_id):
         self.logger.info('Retrieve Assets By Asset Manager: %s', asset_manager_id)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = [
 
 setup(
     name='amaascore',
-    version='0.4.5',
+    version='0.4.6',
     description='Asset Management as a Service - Core SDK',
     license='Apache License 2.0',
     url='https://github.com/amaas-fintech/amaas-core-sdk-python',


### PR DESCRIPTION
Our API already supports searching assets and returning only specified fields.

This change on the sdk side just calls the search api and returns the result as a dictionary.  
There is a separate change in the api (service side) to only query the child tables if they are either in the requested fields or if no fields were specified.  We still need to address the performance (down the line) when children are actually requested.