### PR TITLE
AMAAS-1627 - Remove default close_time and timezone values, as there …

### DIFF
--- a/amaascore/books/book.py
+++ b/amaascore/books/book.py
@@ -16,7 +16,7 @@ class Book(AMaaSModel):
         return ['positions']
 
     def __init__(self, asset_manager_id, book_id=None, book_type='Trading', book_status='Active', owner_id=None,
-                 party_id=None, close_time=datetime.timedelta(hours=18), timezone='UTC', base_currency='USD',
+                 party_id=None, close_time=None, timezone='', base_currency='USD',
                  business_unit='', reference='', description='', positions=None,
                  *args, **kwargs):
         self.asset_manager_id = asset_manager_id


### PR DESCRIPTION
…aren't really any sensible defaults. Plus it means they get set on Counterparty books, which doesn't really make sense.